### PR TITLE
Add support for constraint filters

### DIFF
--- a/model/Column.cs
+++ b/model/Column.cs
@@ -87,6 +87,7 @@ namespace SchemaZen.model {
 					case "timestamp":
 					case "tinyint":
 					case "uniqueidentifier":
+					case "geography":
 					case "xml":
 
 						return string.Format("[{0}] [{1}] {2} {3} {4} {5}", Name, Type, IsNullableText,

--- a/model/Constraint.cs
+++ b/model/Constraint.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Linq;
 
 namespace SchemaZen.model {
 	public class Constraint : INameable, IScriptable {
@@ -9,8 +8,8 @@ namespace SchemaZen.model {
 		public string Name { get; set; }
 		public Table Table;
 		public string Type;
-        public string Filter;
-        public bool Unique;
+		public string Filter;
+		public bool Unique;
 		private bool IsNotForReplication;
 		private string CheckConstraintExpression;
 
@@ -38,7 +37,7 @@ namespace SchemaZen.model {
 			get { return Type != "PRIMARY KEY" && !Unique ? "" : "UNIQUE"; }
 		}
 
-        public string ScriptCreate() {
+		public string ScriptCreate() {
 			if (Type == "CHECK") {
 				var notForReplicationOption = IsNotForReplication ? "NOT FOR REPLICATION" : "";
 				return $"CONSTRAINT [{Name}] CHECK {notForReplicationOption} {CheckConstraintExpression}";
@@ -50,12 +49,12 @@ namespace SchemaZen.model {
 					string.Join("], [", Columns.ToArray()));
 				if (IncludedColumns.Count > 0) {
 					sql += string.Format(" INCLUDE ([{0}])", string.Join("], [", IncludedColumns.ToArray()));
+				}
+				if (!string.IsNullOrEmpty(Filter))
+				{
+                sql += string.Format(" WHERE {0}", Filter);
                 }
-                if (!string.IsNullOrEmpty(Filter))
-                {
-                    sql += string.Format(" WHERE {0}", Filter);
-                }
-                return sql;
+				return sql;
 			}
 			return (Table.IsType ? string.Empty : string.Format("CONSTRAINT [{0}] ", Name)) +
 				string.Format("{0} {1} ([{2}])", Type, ClusteredText, string.Join("], [", Columns.ToArray()));

--- a/model/Constraint.cs
+++ b/model/Constraint.cs
@@ -52,8 +52,8 @@ namespace SchemaZen.model {
 				}
 				if (!string.IsNullOrEmpty(Filter))
 				{
-                sql += string.Format(" WHERE {0}", Filter);
-                }
+				sql += string.Format(" WHERE {0}", Filter);
+				}
 				return sql;
 			}
 			return (Table.IsType ? string.Empty : string.Format("CONSTRAINT [{0}] ", Name)) +

--- a/model/Constraint.cs
+++ b/model/Constraint.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 
 namespace SchemaZen.model {
 	public class Constraint : INameable, IScriptable {
@@ -8,7 +9,8 @@ namespace SchemaZen.model {
 		public string Name { get; set; }
 		public Table Table;
 		public string Type;
-		public bool Unique;
+        public string Filter;
+        public bool Unique;
 		private bool IsNotForReplication;
 		private string CheckConstraintExpression;
 
@@ -36,7 +38,7 @@ namespace SchemaZen.model {
 			get { return Type != "PRIMARY KEY" && !Unique ? "" : "UNIQUE"; }
 		}
 
-		public string ScriptCreate() {
+        public string ScriptCreate() {
 			if (Type == "CHECK") {
 				var notForReplicationOption = IsNotForReplication ? "NOT FOR REPLICATION" : "";
 				return $"CONSTRAINT [{Name}] CHECK {notForReplicationOption} {CheckConstraintExpression}";
@@ -48,8 +50,12 @@ namespace SchemaZen.model {
 					string.Join("], [", Columns.ToArray()));
 				if (IncludedColumns.Count > 0) {
 					sql += string.Format(" INCLUDE ([{0}])", string.Join("], [", IncludedColumns.ToArray()));
-				}
-				return sql;
+                }
+                if (!string.IsNullOrEmpty(Filter))
+                {
+                    sql += string.Format(" WHERE {0}", Filter);
+                }
+                return sql;
 			}
 			return (Table.IsType ? string.Empty : string.Format("CONSTRAINT [{0}] ", Name)) +
 				string.Format("{0} {1} ([{2}])", Type, ClusteredText, string.Join("], [", Columns.ToArray()));

--- a/model/Database.cs
+++ b/model/Database.cs
@@ -457,6 +457,7 @@ order by fk.name, fkc.constraint_column_id
 						i.is_unique_constraint,
 						i.is_unique, 
 						i.type_desc,
+						i.filter_definition,
 						isnull(ic.is_included_column, 0) as is_included_column
 					from (
 						select object_id, name, schema_id, 'T' as baseType
@@ -491,7 +492,9 @@ order by fk.name, fkc.constraint_column_id
 					}
 					c.Clustered = (string) dr["type_desc"] == "CLUSTERED";
 					c.Unique = (bool) dr["is_unique"];
-					if ((bool) dr["is_included_column"]) {
+                    var filter = dr["filter_definition"].ToString();
+				    c.Filter = filter;
+                    if ((bool) dr["is_included_column"]) {
 						c.IncludedColumns.Add((string) dr["columnName"]);
 					} else {
 						c.Columns.Add((string) dr["columnName"]);
@@ -502,7 +505,7 @@ order by fk.name, fkc.constraint_column_id
 						c.Type = "PRIMARY KEY";
 					if ((bool) dr["is_unique_constraint"])
 						c.Type = "UNIQUE";
-				}
+                }
 			}
 		}
 

--- a/model/Database.cs
+++ b/model/Database.cs
@@ -492,9 +492,9 @@ order by fk.name, fkc.constraint_column_id
 					}
 					c.Clustered = (string) dr["type_desc"] == "CLUSTERED";
 					c.Unique = (bool) dr["is_unique"];
-                    var filter = dr["filter_definition"].ToString();
-				    c.Filter = filter;
-                    if ((bool) dr["is_included_column"]) {
+					var filter = dr["filter_definition"].ToString();
+					c.Filter = filter;
+					if ((bool) dr["is_included_column"]) {
 						c.IncludedColumns.Add((string) dr["columnName"]);
 					} else {
 						c.Columns.Add((string) dr["columnName"]);
@@ -505,7 +505,7 @@ order by fk.name, fkc.constraint_column_id
 						c.Type = "PRIMARY KEY";
 					if ((bool) dr["is_unique_constraint"])
 						c.Type = "UNIQUE";
-                }
+				}
 			}
 		}
 

--- a/test/DatabaseTester.cs
+++ b/test/DatabaseTester.cs
@@ -90,6 +90,24 @@ namespace SchemaZen.test {
 		}
 
 		[Test]
+		public void TestTableIndexesWithFilter() {
+			TestHelper.DropDb("TEST");
+			TestHelper.ExecSql("CREATE DATABASE TEST","");
+
+			TestHelper.ExecSql(@"CREATE TABLE MyTable (Id int, EndDate datetime)", "TEST");
+			TestHelper.ExecSql(@"CREATE NONCLUSTERED INDEX MyIndex ON MyTable (Id) WHERE (EndDate) IS NULL","TEST");
+
+			var db = new Database("TEST") {
+				Connection = TestHelper.GetConnString("TEST")
+			};
+			db.Load();
+			var result = db.ScriptCreate();
+			TestHelper.DropDb("TEST");
+
+			Assert.That(result, Is.StringContaining("CREATE  NONCLUSTERED INDEX [MyIndex] ON [dbo].[MyTable] ([Id]) WHERE ([EndDate] IS NULL)"));
+		}
+
+		[Test]
 		[Ignore("test won't work without license key for sqldbdiff")]
 		public void TestDiffScript() {
 			TestHelper.DropDb("TEST_SOURCE");


### PR DESCRIPTION
Table constraints are created without the `where` clause. This adds support for filters.

@colin-hanson-zocdoc @marcio-santos-zocdoc @scott-roepnack-zocdoc 
