### PR TITLE
Change ordder of execution

### DIFF
--- a/model/Database.cs
+++ b/model/Database.cs
@@ -122,7 +122,7 @@ namespace SchemaZen.model {
 
 		private static readonly string[] dirs = {
 			"tables", "foreign_keys", "assemblies", "functions", "procedures", "triggers",
-			"views", "xmlschemacollections", "data", "users", "synonyms", "table_types", "roles"
+			"views", "xmlschemacollections", "data", "roles", "users", "synonyms", "table_types"
 		};
 
 		private void SetPropOnOff(string propName, object dbVal) {


### PR DESCRIPTION
@Tony-Zheng-Zocdoc 

I identified the problem we were having with users in schemazen.  The issue is that the user creation scripts also add users to their roles.  However, roles were being created after the user creation scripts were executed.  So the current flow was basically:
1. Create User
2. Try to add to roles, but the roles don't exist yet
3. Create the roles
4. Try to create the user again, but the user is already created

I changed the order of execution so that the roles get created before the users.  Now we finally have output with 0 errors!

![image](https://cloud.githubusercontent.com/assets/4604503/14021944/f2349192-f1b3-11e5-9d79-4b5e494ed0a7.png)
