### PR TITLE
Support View Indexes with multiple columns

### DIFF
--- a/model/Database.cs
+++ b/model/Database.cs
@@ -600,17 +600,33 @@ order by fk.name, fkc.constraint_column_id
 					order by s.name, t.name, i.name, ic.key_ordinal, ic.index_column_id";
 			using (var dr = cm.ExecuteReader()) {
 				while (dr.Read()) {
-					var t = (string) dr["baseType"] == "V"
-						? new Table((string) dr["schemaName"], (string) dr["tableName"])
-						: FindTable((string) dr["tableName"], (string) dr["schemaName"], ((string) dr["baseType"]) == "TVT");
-					var c = t.FindConstraint((string) dr["indexName"]);
-					if (c == null) {
-						c = new Constraint((string) dr["indexName"], "", "");
-						t.AddConstraint(c);
+				    var schemaName = (string) dr["schemaName"];
+				    var tableName = (string) dr["tableName"];
+				    var indexName = (string) dr["indexName"];
+				    var isView = (string) dr["baseType"] == "V";
 
-						if ((string) dr["baseType"] == "V")
-							ViewIndexes.Add(c);
-					}
+				    var t = isView
+						? new Table(schemaName, tableName)
+						: FindTable(tableName, schemaName, (string) dr["baseType"] == "TVT");
+				    var c = t.FindConstraint( indexName);
+                    
+                    if (c == null)
+                    {
+                        c = new Constraint(indexName, "", "");
+                        t.AddConstraint(c);
+                    }
+
+                    if (isView)
+                    {
+                        if (ViewIndexes.Any(v => v.Name == indexName))
+                        {
+                            c = ViewIndexes.First(v => v.Name == indexName);
+                        }
+                        else
+                        {
+                            ViewIndexes.Add(c);
+                        }
+                    }
 					c.Clustered = (string) dr["type_desc"] == "CLUSTERED";
 					c.Unique = (bool) dr["is_unique"];
 					var filter = dr["filter_definition"].ToString(); //can be null

--- a/test/DatabaseTester.cs
+++ b/test/DatabaseTester.cs
@@ -121,10 +121,31 @@ namespace SchemaZen.test {
 			var result = db.ScriptCreate();
 			TestHelper.DropDb("TEST");
 
-			Assert.That(result, Is.StringContaining("CREATE  NONCLUSTERED INDEX [MyIndex] ON [dbo].[MyTable] ([Id]) WHERE ([EndDate] IS NULL)"));
+			Assert.That(result, Is.StringContaining("CREATE  NONCLUSTERED INDEX [MyIndex] ON [dbo].[MyTable] ([Id] ASC) WHERE ([EndDate] IS NULL)"));
 		}
 
-		[Test]
+        [Test]
+        public void TestViewIndexes()
+        {
+            TestHelper.DropDb("TEST");
+            TestHelper.ExecSql("CREATE DATABASE TEST", "");
+
+            TestHelper.ExecSql(@"CREATE TABLE MyTable (Id int, Name nvarchar(250), EndDate datetime)", "TEST");
+            TestHelper.ExecSql(@"CREATE VIEW dbo.MyView WITH SCHEMABINDING as SELECT t.Id, t.Name, t.EndDate from dbo.MyTable t", "TEST");
+            TestHelper.ExecSql(@"CREATE UNIQUE CLUSTERED INDEX MyIndex ON MyView (Id, Name)", "TEST");
+
+            var db = new Database("TEST")
+            {
+                Connection = TestHelper.GetConnString("TEST")
+            };
+            db.Load();
+            var result = db.ScriptCreate();
+            TestHelper.DropDb("TEST");
+
+            Assert.That(result, Is.StringContaining("CREATE UNIQUE CLUSTERED INDEX [MyIndex] ON [dbo].[MyView] ([Id] ASC, [Name] ASC)"));
+        }
+
+        [Test]
 		[Ignore("test won't work without license key for sqldbdiff")]
 		public void TestDiffScript() {
 			TestHelper.DropDb("TEST_SOURCE");


### PR DESCRIPTION
@colin-hanson-zocdoc @marcio-santos-zocdoc @scott-roepnack-zocdoc 

There's a small bug right now with scripting out views with indexes supporting multiple columns. This ends up being scripted as an index file per column but all under the same index name, which in turn 
causes a conflict.
i.e. View has an index on 4 columns -> 4 index files each 1 column instead of 1 with 4 columns

This came up with the zocdataweb DB
